### PR TITLE
Drop support for Ruby 3.0 and add later versions to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [ "3.0.3", "3.1.1" ]
-    
+        ruby-version: [ "3.1.6", "3.2.6", "3.3.7", "3.4.1" ]
+
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
- Remove Ruby 3.0 from the supported list since it is officially end-of-life
- Add latest versions of Ruby 3.1 onwards to the test matrix